### PR TITLE
docs(artifacts): correct parameter name in docstring example (#4528)

### DIFF
--- a/wandb/sdk/interface/artifacts.py
+++ b/wandb/sdk/interface/artifacts.py
@@ -446,7 +446,7 @@ class Artifact:
 
             Adding a directory without an explicit name:
             ```
-            artifact.add_dir('my_dir/', path='destination') # All files in `my_dir/` are added under `destination/`.
+            artifact.add_dir('my_dir/', name='destination') # All files in `my_dir/` are added under `destination/`.
             ```
 
         Raises:


### PR DESCRIPTION
docs(artifacts): corrected parameter name in docstring example. The correct paramater name is name, not path.

Co-authored-by: Hugh Wimberly <hugh.wimberly@gmail.com>

Fixes WB-NNNN
Fixes #NNNN

Description
-----------
What does the PR do?

Testing
-------
How was this PR tested?

Checklist
-------
- [ ] Include reference to internal ticket "Fixes WB-NNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
- [ ] Ensure PR title compliance with the [conventional commits standards](https://github.com/wandb/wandb/blob/master/CONTRIBUTING.md#conventional-commits)
